### PR TITLE
fix: percentage calculation of echoed raawrs

### DIFF
--- a/ui/src/components/Adventure.svelte
+++ b/ui/src/components/Adventure.svelte
@@ -291,7 +291,7 @@
       <p>
         Echoed RAAWRs: {dinoCard.incomingPongs.length > 0
           ? Math.round(
-              (dinoCard.sentPings / dinoCard.incomingPongs.length) * 100,
+              (dinoCard.incomingPongs.length / dinoCard.sentPings) * 100,
             )
           : 0}%
       </p>


### PR DESCRIPTION
Unfortunately, I can't test this right now as Electron and NixOS don't particularly get along.

However, I think this might be the issue we were seeing because in the example where one sends 30 pings and only recieves 29 pongs, then before it would be `round((30 / 29) * 100) = 103%` Now it will be `round((29 / 30) * 100) = 97%`.

Also, for the other part of the issue, before, if we only got half of the pongs, then it would be `round((30 / 15) * 100) = 200%`.