### PR TITLE
chore: Add direnv support and NixOS electron fix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ npm install
 
 **Run all the other instructions in this README from inside this nix shell, otherwise they won't work**.
 
-## Running 2 agents
+## Running 3 agents
  
 ```bash
 npm run start
 ```
 
-This will create a network of 2 nodes connected to each other and their respective UIs.
+This will create a network of 3 nodes connected to each other and their respective UIs.
 It will also bring up the Holochain Playground for advanced introspection of the conductors.
 
 ## Running the backend tests

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,8 @@
           binaryen
         ]);
 
+        ELECTRON_BINARY = "${pkgs.electron}/bin/electron";
+
         shellHook = ''
           export PS1='\[\033[1;34m\][holonix:\w]\$\[\033[0m\] '
         '';


### PR DESCRIPTION
```nix
ELECTRON_BINARY = "${pkgs.electron}/bin/electron";
```
Is required for `npm run start` to work on NixOS otherwise it tries to use the dynamic Electron binary in node_modules which isn't supported on NixOS.