### PR TITLE
fix: Disable the dig button while digging

### DIFF
--- a/ui/src/components/Adventure.svelte
+++ b/ui/src/components/Adventure.svelte
@@ -187,15 +187,19 @@
   let numNests = $state(10);
   let minNestSize = $state(500);
   let maxNestSize = $state(2000);
+  let diggingNests = $state(false);
 
   const digNests = async (event: SubmitEvent) => {
     event.preventDefault();
+
+    diggingNests = true;
 
     try {
       const nestBatch = await createNestBatch();
 
       const createOne = async (count: number) => {
         if (count <= 0) {
+          diggingNests = false;
           return;
         }
 
@@ -218,6 +222,7 @@
       createOne(numNests).catch(console.error);
     } catch (error) {
       console.error("Failed to create nest batch", error);
+      diggingNests = false;
     }
   };
 
@@ -357,7 +362,14 @@
           />
         </label>
 
-        <button type="submit" class="btn btn-primary">DIG!</button>
+        <button type="submit" class="btn btn-primary" disabled={diggingNests}>
+          {#if diggingNests}
+            <span class="loading loading-spinner loading-sm"></span>
+            Digging...
+          {:else}
+            DIG!
+          {/if}
+        </button>
       </form>
     </div>
   </div>


### PR DESCRIPTION
This makes it clearer that the app is still working on something while the digging is happening and prevents the user from accidentally clicking the button multiples times and not realizing that it's busy.

Thanks #claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a loading state to the Dig action: the button now shows a spinner and “Digging…” while processing.
  * The Dig button is temporarily disabled during processing to prevent repeated clicks.
  * The button automatically returns to its normal state when the action completes or if an error occurs, providing clearer feedback and a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->