### PR TITLE
chore: upgrade to holochain v0.7.0-dev.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,9 +370,9 @@ checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "hdi"
-version = "0.7.0"
+version = "0.8.0-dev.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c318d6153db1a7d77b0dea6c89a74345bac9d7ada3046f539e21cc00e4d243db"
+checksum = "bd0f68e2bd2787008dd1055e44c78d659aef5dea0618f9ac859965a19fb227e2"
 dependencies = [
  "getrandom",
  "hdk_derive",
@@ -390,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "hdk"
-version = "0.6.0"
+version = "0.7.0-dev.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c5a6731e79600361357cf9abc22ffd12d54036534592e9ffaff1da1fed453a"
+checksum = "7d816412a4634ffbf54033cec1f88c8f949398d90aeeb4d36e4c907d96dee7f3"
 dependencies = [
  "getrandom",
  "hdi",
@@ -408,9 +408,9 @@ dependencies = [
 
 [[package]]
 name = "hdk_derive"
-version = "0.6.0"
+version = "0.7.0-dev.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b9cecd43529636ef83f04becec2d0aa44d9489feee4ae918934a6785e6e002"
+checksum = "37c9df777f2ba3c594f74a6bfc4cf9b411c3bb03a9e5b14881884258690826c9"
 dependencies = [
  "darling",
  "heck",
@@ -430,9 +430,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "holo_hash"
-version = "0.6.0"
+version = "0.7.0-dev.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d4d7ada0089a52dc48498e4deab38c056b665a666b5f8717161c8d0248fd31e"
+checksum = "d36c4e3f378c453360851a8db26e66a008bb0108e8c85371350204e0d60b2048"
 dependencies = [
  "base64",
  "blake2b_simd",
@@ -450,9 +450,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_integrity_types"
-version = "0.6.0"
+version = "0.7.0-dev.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23114491d121f97fe2d5095b412cfcb84c009187bfe1fcaca6c32ff0119f1a4b"
+checksum = "7894780e10cddca13821c7a5f6846b44d76d7020945229582afae53c32604b91"
 dependencies = [
  "holo_hash",
  "holochain_secure_primitive",
@@ -467,9 +467,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_nonce"
-version = "0.6.0"
+version = "0.7.0-dev.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75da59d1c721c95502fee9a346a34fab6fd6364a39eb5e78f19688ff9cb9abbb"
+checksum = "715d0dae744ec354efa59e651da01efe7fd566d8f31662d40d5e90c020f267cd"
 dependencies = [
  "getrandom",
  "holochain_secure_primitive",
@@ -478,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_secure_primitive"
-version = "0.6.0"
+version = "0.7.0-dev.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e28bdc1ec5fc4a8a7d96a95d12762297fe5c819b881273b2927d2fa19456ded"
+checksum = "de8645a93a6840b41441742e5a03fae18399dd1336c07f18f12d3ad27c8da266"
 dependencies = [
  "paste",
  "serde",
@@ -514,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_timestamp"
-version = "0.6.0"
+version = "0.7.0-dev.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6baf669811b4b70912408b9191127836a1a38c9ea690bcaa4c245d09fcf9253"
+checksum = "aa0f4b1711e18d73420f075a152090ffeb1e285271b3f80106c49d10d58c6d59"
 dependencies = [
  "chrono",
  "serde",
@@ -524,9 +524,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_util"
-version = "0.6.0"
+version = "0.7.0-dev.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d10cf3ca40b04f1e180817d9b059d1fe11b3e05e3127c0a5f0ad4651ddad6cb"
+checksum = "c96d1a2e73cf4344650b63a0cbda9f86a04599bc8c16822df834f5bb697c3eba"
 dependencies = [
  "cfg-if",
  "colored",
@@ -562,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-version = "0.6.0"
+version = "0.7.0-dev.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b31902b3b626e91bfcc0f102bd04fe065eca18f10dab4b15e058d55cd5958f"
+checksum = "8f39f979572a946325b0385c3ead73a7af5e92c9cf2dad5ec23924bd8f695ac8"
 dependencies = [
  "derive_more",
  "holo_hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ members = ["dnas/*/zomes/coordinator/*", "dnas/*/zomes/integrity/*"]
 resolver = "2"
 
 [workspace.dependencies]
-hdi = "=0.7.0"
-hdk = "=0.6.0"
+hdi = "=0.8.0-dev.2"
+hdk = "=0.7.0-dev.3"
 serde = "1.0"
 rand = "0.9"
 holochain_serialized_bytes = "*"

--- a/flake.lock
+++ b/flake.lock
@@ -33,36 +33,19 @@
         "type": "github"
       }
     },
-    "hc-launch": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1763633869,
-        "narHash": "sha256-eRv1oT9be14R0x8hhs5PWPRKX2QC6rmrtEkmnuvvetA=",
-        "owner": "holochain",
-        "repo": "hc-launch",
-        "rev": "0bc4854dc5359340ff5b0ba00dc8ce970a43184e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "holochain",
-        "ref": "holochain-weekly",
-        "repo": "hc-launch",
-        "type": "github"
-      }
-    },
     "hc-scaffold": {
       "flake": false,
       "locked": {
-        "lastModified": 1760566803,
-        "narHash": "sha256-fWflEEb2JQyVHfGglbx6dCR6X+4ECGM9pbxQYrKSZtQ=",
+        "lastModified": 1764163563,
+        "narHash": "sha256-KigJ3h25yNJfeQunPm5QYFPtLSk6nU3IEEvZY8w01Vo=",
         "owner": "holochain",
         "repo": "scaffolding",
-        "rev": "751a16e98ddb35db5763cbf4b882a849b642e7e7",
+        "rev": "87e997a7361d4aa7c1bb96261483ebba50223bd0",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "0.600.0-dev.0",
+        "ref": "v0.600.1",
         "repo": "scaffolding",
         "type": "github"
       }
@@ -70,16 +53,16 @@
     "holochain": {
       "flake": false,
       "locked": {
-        "lastModified": 1763554421,
-        "narHash": "sha256-uCVTHeoJpDcc3Ky6gXt1oZX7XxVL3CmY9pFVQ5AEXtM=",
+        "lastModified": 1768178786,
+        "narHash": "sha256-JsYqXKZMkt4v0hd7dA3GCs8ELuLEoiectSY4Zw9pWJw=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "a6d4e805a0971ccbc0dcb3f3ed6a9e2fac980a3b",
+        "rev": "6594a0ed6a038113bc55e0c1545310736189d88b",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-0.6.0",
+        "ref": "holochain-0.7.0-dev.7",
         "repo": "holochain",
         "type": "github"
       }
@@ -88,7 +71,6 @@
       "inputs": {
         "crane": "crane",
         "flake-parts": "flake-parts",
-        "hc-launch": "hc-launch",
         "hc-scaffold": "hc-scaffold",
         "holochain": "holochain",
         "kitsune2": "kitsune2",
@@ -98,11 +80,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1763654899,
-        "narHash": "sha256-o4V5QiJAlZHK7jf/GxCrlhtuu+W0ljMDp6wb8DOMRrQ=",
+        "lastModified": 1768299200,
+        "narHash": "sha256-wg7yUc/n6iYf5/qgV2tosZimJu0iTLVZOouko95TuiM=",
         "owner": "holochain",
         "repo": "holonix",
-        "rev": "d21b35431e425e615bc05da790987380a84b8280",
+        "rev": "70c034a9eedfd3d48450432f938b86dc11202361",
         "type": "github"
       },
       "original": {
@@ -148,11 +130,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1763334038,
-        "narHash": "sha256-LBVOyaH6NFzQ3X/c6vfMZ9k4SV2ofhpxeL9YnhHNJQQ=",
+        "lastModified": 1763622513,
+        "narHash": "sha256-1jQnuyu82FpiSxowrF/iFK6Toh9BYprfDqfs4BB+19M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4c8cdd5b1a630e8f72c9dd9bf582b1afb3127d2c",
+        "rev": "c58bc7f5459328e4afac201c5c4feb7c818d604b",
         "type": "github"
       },
       "original": {
@@ -215,11 +197,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1763519912,
-        "narHash": "sha256-N2YN0ZNBoz2zRRjmATePp9GbmGSGpVh3+piXn6mtgKc=",
+        "lastModified": 1763692705,
+        "narHash": "sha256-tCKCyMYU0Vy+ph/xswlNsYXXjnFVweWBV+ew/5FS9tA=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "a9c35d6e7cb70c5719170b6c2d3bb589c5e048af",
+        "rev": "6fbf5d328dce1828d887b8ee7d44a785196a34e7",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
         inputsFrom = [ inputs'.holonix.devShells.default ];
 
         packages = (with pkgs; [
-          nodejs_20
+          nodejs_24
           binaryen
         ]);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       ],
       "devDependencies": {
         "@eslint/js": "^9.26.0",
-        "@holochain/hc-spin": "0.600.0",
+        "@holochain/hc-spin": "0.700.0-dev.0",
         "concurrently": "^9.1.0",
         "eslint": "^9.26.0",
         "get-port-cli": "^3.0.0",
@@ -736,16 +736,16 @@
       }
     },
     "node_modules/@holochain/hc-spin": {
-      "version": "0.600.0",
-      "resolved": "https://registry.npmjs.org/@holochain/hc-spin/-/hc-spin-0.600.0.tgz",
-      "integrity": "sha512-dG2Ics7lgYkVb1AxUOgFR45xLkK2xus7i7/orQnteDI9j7egGcFRHq7u9qkFW5AQAP9RFiLX7Z+lZxek2ZajUQ==",
+      "version": "0.700.0-dev.0",
+      "resolved": "https://registry.npmjs.org/@holochain/hc-spin/-/hc-spin-0.700.0-dev.0.tgz",
+      "integrity": "sha512-xw6UzDfglMo0TunAI5DzjcdasMPcAcrkXS/qqrdBeNxEjIyiZaea23YTzBnb4bmC4XEqX+9I2VT8n+BaccLCJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.0",
         "@electron-toolkit/utils": "^3.0.0",
         "@holochain/client": "^0.20.0",
-        "@holochain/hc-spin-rust-utils": "0.600.0",
+        "@holochain/hc-spin-rust-utils": "0.700.0-dev.0",
         "@msgpack/msgpack": "^2.8.0",
         "bufferutil": "4.0.8",
         "commander": "11.1.0",
@@ -761,26 +761,26 @@
       }
     },
     "node_modules/@holochain/hc-spin-rust-utils": {
-      "version": "0.600.0",
-      "resolved": "https://registry.npmjs.org/@holochain/hc-spin-rust-utils/-/hc-spin-rust-utils-0.600.0.tgz",
-      "integrity": "sha512-gseESyOrnoht22WsrZzfi/gR3jwgtypw3gErqDL8jYD5tYuqo0ibXZwDvmCBSAWDSxc1ZSWGRsWH09ZvxxAeDw==",
+      "version": "0.700.0-dev.0",
+      "resolved": "https://registry.npmjs.org/@holochain/hc-spin-rust-utils/-/hc-spin-rust-utils-0.700.0-dev.0.tgz",
+      "integrity": "sha512-zh31p03+UFwD9uCBwnu/fnFw+e597TxhYXkuws1Qod5QuKlT0uIg29hd5GiTfzgrQk9umelgPr1wNJbzxmAVuQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "@holochain/hc-spin-rust-utils-darwin-arm64": "0.600.0",
-        "@holochain/hc-spin-rust-utils-darwin-x64": "0.600.0",
-        "@holochain/hc-spin-rust-utils-linux-arm64-gnu": "0.600.0",
-        "@holochain/hc-spin-rust-utils-linux-x64-gnu": "0.600.0",
-        "@holochain/hc-spin-rust-utils-win32-x64-msvc": "0.600.0"
+        "@holochain/hc-spin-rust-utils-darwin-arm64": "0.700.0-dev.0",
+        "@holochain/hc-spin-rust-utils-darwin-x64": "0.700.0-dev.0",
+        "@holochain/hc-spin-rust-utils-linux-arm64-gnu": "0.700.0-dev.0",
+        "@holochain/hc-spin-rust-utils-linux-x64-gnu": "0.700.0-dev.0",
+        "@holochain/hc-spin-rust-utils-win32-x64-msvc": "0.700.0-dev.0"
       }
     },
     "node_modules/@holochain/hc-spin-rust-utils-darwin-arm64": {
-      "version": "0.600.0",
-      "resolved": "https://registry.npmjs.org/@holochain/hc-spin-rust-utils-darwin-arm64/-/hc-spin-rust-utils-darwin-arm64-0.600.0.tgz",
-      "integrity": "sha512-tvU5vBHkkGRSD9K+3HWkTySX7XK+vdD35x3x/4pQ5J/31gRMKcRbrP0W1n7mTOyFUWQjgNHnLJeTM3yt2a7tbA==",
+      "version": "0.700.0-dev.0",
+      "resolved": "https://registry.npmjs.org/@holochain/hc-spin-rust-utils-darwin-arm64/-/hc-spin-rust-utils-darwin-arm64-0.700.0-dev.0.tgz",
+      "integrity": "sha512-Oyszp4d8V1NLS7UfAoNg66/x9+JHMpBf/+i+lK0+iHQBHa4eXVF2AO1VCGTr/LwN/wz5kgKjOh43N4C7EPgsiQ==",
       "cpu": [
         "arm64"
       ],
@@ -795,9 +795,9 @@
       }
     },
     "node_modules/@holochain/hc-spin-rust-utils-darwin-x64": {
-      "version": "0.600.0",
-      "resolved": "https://registry.npmjs.org/@holochain/hc-spin-rust-utils-darwin-x64/-/hc-spin-rust-utils-darwin-x64-0.600.0.tgz",
-      "integrity": "sha512-Mewfh8JC49/kXMRNT4Y+ObwrjNk0FTN9aOrStsmRVXfvb4naCRnuExfz3X8iMB85b6SBPxc0lyCC9A4YGvUFPw==",
+      "version": "0.700.0-dev.0",
+      "resolved": "https://registry.npmjs.org/@holochain/hc-spin-rust-utils-darwin-x64/-/hc-spin-rust-utils-darwin-x64-0.700.0-dev.0.tgz",
+      "integrity": "sha512-f01n+Na/fM00ikj8GKl26AC8bwR2/d6UN63ZHnHuwpOQbhm3ZxcU3oXuoJ7msm8XgWO8AaKa2WXb0uG56IJJPw==",
       "cpu": [
         "x64"
       ],
@@ -812,9 +812,9 @@
       }
     },
     "node_modules/@holochain/hc-spin-rust-utils-linux-arm64-gnu": {
-      "version": "0.600.0",
-      "resolved": "https://registry.npmjs.org/@holochain/hc-spin-rust-utils-linux-arm64-gnu/-/hc-spin-rust-utils-linux-arm64-gnu-0.600.0.tgz",
-      "integrity": "sha512-o/RGxy+2hvvN5S8OnVnOLQyx9uiwT2tBSnGbyYZHkZTzipi9eVczOlLlNQnck3s3ApxwAv+FP7dDLJBVxZjmRA==",
+      "version": "0.700.0-dev.0",
+      "resolved": "https://registry.npmjs.org/@holochain/hc-spin-rust-utils-linux-arm64-gnu/-/hc-spin-rust-utils-linux-arm64-gnu-0.700.0-dev.0.tgz",
+      "integrity": "sha512-S9s2crcwhIGTPLYyolvZF49iYafe+CrdeWW4Kh1Wn954JmgVVWdC8oUIizHViwqAUjeiiVpy4Eu1i79UmoNaTw==",
       "cpu": [
         "arm64"
       ],
@@ -829,9 +829,9 @@
       }
     },
     "node_modules/@holochain/hc-spin-rust-utils-linux-x64-gnu": {
-      "version": "0.600.0",
-      "resolved": "https://registry.npmjs.org/@holochain/hc-spin-rust-utils-linux-x64-gnu/-/hc-spin-rust-utils-linux-x64-gnu-0.600.0.tgz",
-      "integrity": "sha512-nr2prm4tlB3inRnQANc6W2M/8JleBTWbleSJ4tdFmS0U2xjoKBLGYmp6TjeTwLAod/99qCNiYoVFblQhxWcZ4w==",
+      "version": "0.700.0-dev.0",
+      "resolved": "https://registry.npmjs.org/@holochain/hc-spin-rust-utils-linux-x64-gnu/-/hc-spin-rust-utils-linux-x64-gnu-0.700.0-dev.0.tgz",
+      "integrity": "sha512-QwRBI0d1jV4GnPaNvt74R4uIPTcojeyeU6IqvbyYj9ptJ0+BEJBpRLsVDyKBVZonQqQwwTWKVkMX0/Uugj0qIw==",
       "cpu": [
         "x64"
       ],
@@ -846,9 +846,9 @@
       }
     },
     "node_modules/@holochain/hc-spin-rust-utils-win32-x64-msvc": {
-      "version": "0.600.0",
-      "resolved": "https://registry.npmjs.org/@holochain/hc-spin-rust-utils-win32-x64-msvc/-/hc-spin-rust-utils-win32-x64-msvc-0.600.0.tgz",
-      "integrity": "sha512-RRyyN+51o7E8TuaKtS3xTAOyh2vVa39dhvY7Tr9EQLxSI9EO1xn4nM+3ZYqSCKPiSUlZ44DwOSrwgmbm2o/9xg==",
+      "version": "0.700.0-dev.0",
+      "resolved": "https://registry.npmjs.org/@holochain/hc-spin-rust-utils-win32-x64-msvc/-/hc-spin-rust-utils-win32-x64-msvc-0.700.0-dev.0.tgz",
+      "integrity": "sha512-pRf9ZroE83jI/GDXZWV9aLBxwiUoz9u7UV2I1LCqO2dnj6NKmLSBloM7r5ISTb1zruqoMt9oQprhNLZM21aZxQ==",
       "cpu": [
         "x64"
       ],
@@ -1499,6 +1499,7 @@
       "integrity": "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
         "debug": "^4.4.1",
@@ -1908,6 +1909,7 @@
       "integrity": "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1992,6 +1994,7 @@
       "integrity": "sha512-Zhy8HCvBUEfBECzIl1PKqF4p11+d0aUJS1GeUiuqK9WmOug8YCmC4h4bjyBvMyAMI9sbRczmrYL5lKg/YMbrcQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.38.0",
         "@typescript-eslint/types": "8.38.0",
@@ -2331,6 +2334,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2661,6 +2665,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -3310,6 +3315,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^20.9.0",
@@ -3550,6 +3556,7 @@
       "integrity": "sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4541,9 +4548,9 @@
       }
     },
     "node_modules/js-base64": {
-      "version": "3.7.7",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
-      "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==",
+      "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
+      "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
       "license": "BSD-3-Clause"
     },
     "node_modules/js-sha512": {
@@ -4769,7 +4776,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4790,7 +4796,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4811,7 +4816,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4832,7 +4836,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4853,7 +4856,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4874,7 +4876,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4895,7 +4896,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4916,7 +4916,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4937,7 +4936,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4958,7 +4956,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5702,6 +5699,7 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6572,6 +6570,7 @@
       "integrity": "sha512-LnSywHHQM/nJekC65d84T1Yo85IeCYN4AryWYPhTokSvcEAFdYFCfbMhX1mc0zHizT736QQj0nalUk+SXaWrEQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -6718,6 +6717,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6858,6 +6858,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6970,6 +6971,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -7080,6 +7082,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7318,6 +7321,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -7451,11 +7455,31 @@
     "tests": {
       "version": "0.1.0",
       "dependencies": {
-        "@holochain/client": "^0.20.0-dev.2",
+        "@holochain/client": "^0.21.0-dev.1",
         "@holochain/tryorama": "^0.19.0-dev.2",
         "@msgpack/msgpack": "^3.1.1",
         "typescript": "^5.8",
         "vitest": "^3.1"
+      }
+    },
+    "tests/node_modules/@holochain/client": {
+      "version": "0.21.0-dev.1",
+      "resolved": "https://registry.npmjs.org/@holochain/client/-/client-0.21.0-dev.1.tgz",
+      "integrity": "sha512-CK6kQ5KG083CUJiG3UC9SPHhD+chjDwVU8XO4XPS0LV/1jmlgUbBEaMKbwZUa4OsIw7ePB+3S7j7vqe6kwPdxw==",
+      "license": "CAL-1.0",
+      "dependencies": {
+        "@bitgo/blake2b": "^3.2.4",
+        "@msgpack/msgpack": "^3.1.2",
+        "emittery": "^1.2.0",
+        "isomorphic-ws": "^5.0.0",
+        "js-base64": "^3.7.8",
+        "js-sha512": "^0.9.0",
+        "libsodium-wrappers": "^0.8",
+        "lodash-es": "^4.17.21",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0 || >=22.0.0 || >= 24.0.0"
       }
     },
     "tests/node_modules/@msgpack/msgpack": {
@@ -7467,10 +7491,25 @@
         "node": ">= 18"
       }
     },
+    "tests/node_modules/libsodium": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.8.0.tgz",
+      "integrity": "sha512-GQ4Sg0/Z0Ui6ZvKeTd8bH7VAAqk1ZHZDAo/pcuSi0uPbIN6LYAAotR0GEYb8v+y4/tSsXZPr06D6hhqKd7tnoQ==",
+      "license": "ISC"
+    },
+    "tests/node_modules/libsodium-wrappers": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.8.0.tgz",
+      "integrity": "sha512-PVyXAtP1nmpQrDKAVnA8pir0f7bj7vmMGs7mb+0OCSJ+BOfLNBb5hPy2GHfrx6cQ+Co9fMliR5R0WRbVuMllNA==",
+      "license": "ISC",
+      "dependencies": {
+        "libsodium": "^0.8.0"
+      }
+    },
     "ui": {
       "version": "0.1.0",
       "dependencies": {
-        "@holochain/client": "^0.20.0",
+        "@holochain/client": "^0.21.0-dev.1",
         "@msgpack/msgpack": "^3.1.1"
       },
       "devDependencies": {
@@ -7487,6 +7526,26 @@
         "vite": "^6.0.0"
       }
     },
+    "ui/node_modules/@holochain/client": {
+      "version": "0.21.0-dev.1",
+      "resolved": "https://registry.npmjs.org/@holochain/client/-/client-0.21.0-dev.1.tgz",
+      "integrity": "sha512-CK6kQ5KG083CUJiG3UC9SPHhD+chjDwVU8XO4XPS0LV/1jmlgUbBEaMKbwZUa4OsIw7ePB+3S7j7vqe6kwPdxw==",
+      "license": "CAL-1.0",
+      "dependencies": {
+        "@bitgo/blake2b": "^3.2.4",
+        "@msgpack/msgpack": "^3.1.2",
+        "emittery": "^1.2.0",
+        "isomorphic-ws": "^5.0.0",
+        "js-base64": "^3.7.8",
+        "js-sha512": "^0.9.0",
+        "libsodium-wrappers": "^0.8",
+        "lodash-es": "^4.17.21",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0 || >=22.0.0 || >= 24.0.0"
+      }
+    },
     "ui/node_modules/@msgpack/msgpack": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.2.tgz",
@@ -7494,6 +7553,21 @@
       "license": "ISC",
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "ui/node_modules/libsodium": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.8.0.tgz",
+      "integrity": "sha512-GQ4Sg0/Z0Ui6ZvKeTd8bH7VAAqk1ZHZDAo/pcuSi0uPbIN6LYAAotR0GEYb8v+y4/tSsXZPr06D6hhqKd7tnoQ==",
+      "license": "ISC"
+    },
+    "ui/node_modules/libsodium-wrappers": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.8.0.tgz",
+      "integrity": "sha512-PVyXAtP1nmpQrDKAVnA8pir0f7bj7vmMGs7mb+0OCSJ+BOfLNBb5hPy2GHfrx6cQ+Co9fMliR5R0WRbVuMllNA==",
+      "license": "ISC",
+      "dependencies": {
+        "libsodium": "^0.8.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "launch:happ": "hc-spin -n $AGENTS --ui-port $UI_PORT workdir/DinoAdventure.happ",
     "start:tauri": "AGENTS=${AGENTS:-2} BOOTSTRAP_PORT=$(get-port) npm run network:tauri",
     "network:tauri": "hc sandbox clean && npm run build:happ && UI_PORT=$(get-port) concurrently \"npm run start --workspace ui\" \"npm run launch:tauri\" \"holochain-playground\"",
-    "launch:tauri": "concurrently \"kitsune2-bootstrap-srv --listen $BOOTSTRAP_PORT\" \"echo pass | RUST_LOG=warn hc launch --piped -n $AGENTS workdir/DinoAdventure.happ --ui-port $UI_PORT network --bootstrap http://127.0.0.1:\"$BOOTSTRAP_PORT\" webrtc ws://127.0.0.1:\"$BOOTSTRAP_PORT\"\"",
+    "launch:tauri": "concurrently \"kitsune2-bootstrap-srv --listen 127.0.0.1:$BOOTSTRAP_PORT\" \"echo pass | RUST_LOG=warn hc launch --piped -n $AGENTS workdir/DinoAdventure.happ --ui-port $UI_PORT network --bootstrap http://127.0.0.1:\"$BOOTSTRAP_PORT\" webrtc ws://127.0.0.1:\"$BOOTSTRAP_PORT\"\"",
     "package": "npm run build:happ && npm run package --workspace ui && hc web-app pack workdir --recursive",
     "build:happ": "npm run build:zomes && hc app pack workdir --recursive",
     "build:zomes": "RUSTFLAGS=\"--cfg getrandom_backend=\\\"custom\\\"\" cargo build --release --target wasm32-unknown-unknown",
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.26.0",
-    "@holochain/hc-spin": "0.600.0",
+    "@holochain/hc-spin": "0.700.0-dev.0",
     "concurrently": "^9.1.0",
     "get-port-cli": "^3.0.0",
     "prettier": "^3.5.3",

--- a/tests/package.json
+++ b/tests/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@msgpack/msgpack": "^3.1.1",
-    "@holochain/client": "^0.20.0-dev.2",
+    "@holochain/client": "^0.21.0-dev.1",
     "@holochain/tryorama": "^0.19.0-dev.2",
     "typescript": "^5.8",
     "vitest": "^3.1"

--- a/tests/src/dino_adventure/dino_adventure/invite.test.ts
+++ b/tests/src/dino_adventure/dino_adventure/invite.test.ts
@@ -1,6 +1,6 @@
 import { test } from "vitest";
 import { AppWithOptions, runScenario } from "@holochain/tryorama";
-import { SignalType } from "@holochain/client";
+import { Signal, SignalType } from "@holochain/client";
 import type {
   AdventureInvite,
   AdventureInviteAcceptance,
@@ -14,7 +14,9 @@ test("invite and accept", async () => {
     const testAppPath = process.cwd() + "/../workdir/DinoAdventure.happ";
 
     // Set up the app to be installed
-    const appWithOptions: AppWithOptions = { appBundleSource: { type: "path", value: testAppPath } };
+    const appWithOptions: AppWithOptions = {
+      appBundleSource: { type: "path", value: testAppPath },
+    };
 
     const [alice, bob] = await scenario.addPlayersWithApps([
       appWithOptions,
@@ -26,7 +28,7 @@ test("invite and accept", async () => {
 
     const bobReceiver = new Promise((resolve, reject) => {
       setTimeout(() => reject(new Error("bob did not get an invite")), 30_000);
-      bob.appWs.on("signal", (signal) => {
+      bob.appWs.on("signal", (signal: Signal) => {
         if (signal.type === SignalType.App) {
           const sig = signal.value.payload as DinoAdventureSignal;
           if (sig.type === "AdventureInvite") {
@@ -52,7 +54,7 @@ test("invite and accept", async () => {
         () => reject(new Error("alice did not get an accept")),
         30_000,
       );
-      alice.appWs.on("signal", (signal) => {
+      alice.appWs.on("signal", (signal: Signal) => {
         if (signal.type === SignalType.App) {
           const sig = signal.value.payload as DinoAdventureSignal;
           if (sig.type === "InviteAcceptance") {

--- a/tests/src/dino_adventure/dino_adventure/ping.test.ts
+++ b/tests/src/dino_adventure/dino_adventure/ping.test.ts
@@ -1,6 +1,6 @@
 import { test } from "vitest";
 import { AppWithOptions, runScenario } from "@holochain/tryorama";
-import { SignalType } from "@holochain/client";
+import { Signal, SignalType } from "@holochain/client";
 import type { DinoAdventureSignal } from "ui/src/types";
 
 test("send ping", async () => {
@@ -10,7 +10,9 @@ test("send ping", async () => {
     const testAppPath = process.cwd() + "/../workdir/DinoAdventure.happ";
 
     // Set up the app to be installed
-    const appWithOptions: AppWithOptions = { appBundleSource: { type: "path", value: testAppPath } };
+    const appWithOptions: AppWithOptions = {
+      appBundleSource: { type: "path", value: testAppPath },
+    };
 
     const [alice, bob] = await scenario.addPlayersWithApps([
       appWithOptions,
@@ -22,7 +24,7 @@ test("send ping", async () => {
 
     const bobReceiver = new Promise((resolve, reject) => {
       setTimeout(() => reject(new Error("bob did not get a ping")), 30_000);
-      bob.appWs.on("signal", (signal) => {
+      bob.appWs.on("signal", (signal: Signal) => {
         if (signal.type === SignalType.App) {
           const sig = signal.value.payload as DinoAdventureSignal;
           if (sig.type === "IncomingPing") {
@@ -34,7 +36,7 @@ test("send ping", async () => {
 
     const aliceReceiver = new Promise((resolve, reject) => {
       setTimeout(() => reject(new Error("alice did not get a pong")), 30_000);
-      alice.appWs.on("signal", (signal) => {
+      alice.appWs.on("signal", (signal: Signal) => {
         if (signal.type === SignalType.App) {
           const sig = signal.value.payload as DinoAdventureSignal;
           if (sig.type === "IncomingPong") {

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@holochain/client": "^0.20.0",
+    "@holochain/client": "^0.21.0-dev.1",
     "@msgpack/msgpack": "^3.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrade to holochain-0.7.0-dev.6.
`hc-spin` dependency upgraded as well, tests pass with previous Tryorama.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated core Holochain and related dev tooling to newer pre-release versions across the workspace
  * Bumped Holochain client packages in test and UI modules
  * Updated development environment configuration and dev packages
  * Modified bootstrap service to bind explicitly to localhost

* **Tests**
  * Strengthened signal typing in integration tests and applied minor formatting adjustments

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->